### PR TITLE
link libVsockMsgDispatch with libbase_ndk

### DIFF
--- a/jni/Android.bp
+++ b/jni/Android.bp
@@ -50,7 +50,8 @@ cc_library_shared {
        "-Wno-unused-parameter",
        "-Wno-unused-label",
     ],
-    shared_libs: ["libbase", "liblog"],
+    shared_libs: ["liblog"],
+    static_libs: ["libbase_ndk"],
     sdk_version: "current",
 }
     


### PR DESCRIPTION
Statically link libase_ndk with libVsockMsgDispatch, instead of libbase, as libbase does not have
sdk_version set

Tracked-On: OAM-104815
Signed-off-by: ahs <amrita.h.s@intel.com>