### PR TITLE
Fixing for Clipboard-Agent Coverity issues

### DIFF
--- a/jni/Android.bp
+++ b/jni/Android.bp
@@ -49,6 +49,7 @@ cc_library_shared {
        "-Werror",
        "-Wno-unused-parameter",
        "-Wno-unused-label",
+       "-fexceptions" 
     ],
     shared_libs: ["liblog"],
     static_libs: ["libbase_ndk"],

--- a/jni/DispatchHelper.cpp
+++ b/jni/DispatchHelper.cpp
@@ -2,6 +2,7 @@
 #include "DispatchHelper.h"
 #include <string.h>
 #include <jni.h>
+#include "android/log.h"
 
 using namespace vsock;
 std::map< std::string, std::vector<MSG_TYPE> > comp_msg_map {
@@ -66,12 +67,23 @@ class JavaComponent:public Component {
    private:
        jclass GetJClass() {
            std::map< std::string, jclass >::iterator it;
-           jclass reqClass = nullptr; 
-           it = jclass_map.find(java_class_name.c_str());
+           jclass reqClass = nullptr;
+       try
+       {
+          // Coverity fix: The following code may throw an exception of type std::length_error.
+          it = jclass_map.find(java_class_name.c_str());
            if (it != jclass_map.end()) {
                reqClass = it->second;
-           } 
-	   return reqClass;
+           }
+      }
+      catch (const std::exception& e)
+      {
+        // Coverity fix: GetJClass (typically used to report errors) may throw an
+        // exception of type std::length_error.
+        LOG(INFO) << "WARNING:GetJClass throw an exception" << e.what() << std::endl; 
+     }
+       return reqClass;
+             
        }
 
        jobject GetSingletonInstance(jclass reqClass) {


### PR DESCRIPTION
Fixing for Clipboard-Agent Coverity issues

Coverity scan reported
exn_spec_violation An exception of type std::length_error

Test done: Boot and Functional test passed with engineering build.

Tracked-On: OAM-112451